### PR TITLE
Fixed so it doesn't break when the HTML contains a link immediately foll...

### DIFF
--- a/lib/premailer/premailer.rb
+++ b/lib/premailer/premailer.rb
@@ -309,7 +309,7 @@ protected
 
           # if the file does not exist locally, try to grab the remote reference
           if link_uri.nil? or not File.exists?(link_uri)
-            link_uri = Premailer.resolve_link(tag.attributes['href'].to_s, @html_file)
+            link_uri = Premailer.resolve_link(tag.attributes['href'].to_s)
           end
 
           if Premailer.local_data?(link_uri)
@@ -464,7 +464,7 @@ public
   end
 
   # @private
-  def self.resolve_link(path, base_path) # :nodoc:
+  def self.resolve_link(path, base_path = nil) # :nodoc:
     path.strip!
     resolved = nil
     if path =~ /(http[s]?|ftp):\/\//i
@@ -477,7 +477,7 @@ public
       resolved = URI.parse(base_path)
       resolved = resolved.merge(path)
       Premailer.canonicalize(resolved)
-    else
+    elsif base_path
       File.expand_path(path, File.dirname(base_path))
     end
   end


### PR DESCRIPTION
...owing a newline

The problem was that the entire HTML source was passed in to resolve_link as base_path, even though it makes no sense.

Most of the time, however, that was okay, because it wasn't a URI nor did it match the http regexp. But, since the regexp matches ^ at each newline, if the HTML had \nhttp:// or \nftp:// or \nhttps:// anywhere in it, it would error, because it would try to URI.parse the entire HTML source.
